### PR TITLE
Adding support for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "kreativekorp/barcode",
+    "type": "library",
+    "description": "Generate barcodes from a single PHP file.",
+    "homepage": "https://github.com/kreativekorp/barcode/",
+    "license": [
+      "MIT"
+    ],
+    "authors": [
+        {
+            "name": "Kreative Software",
+            "email": "support@kreativekorp.com",
+            "homepage": "http://www.kreativekorp.com"
+        }
+    ],
+    "autoload": {
+        "classmap": ["barcode.php"]
+    }
+}


### PR DESCRIPTION
CWINFO (@cwinfo)
-------------------------
[Composer](https://getcomposer.org/) is Dependency Manager for PHP. It can be used to easily add functions to different projects. Composer makes sure that all dependencies are met.

Using Composer requires making releases after doing changes to code. You need to create release after PR so people can start using this with composer.

I created temporary release in my fork for my private use :smile: