### PR TITLE
Added Group Separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ barcode.php?f=svg&s=qr&d=HELLO%20WORLD&sf=8&ms=r&md=0.8
 - if needed, you can replace `\FNC1` keyword with `yourKeyword` in barcode.php file, the functionality will remain. Do not forget to replace all occurrences.
 - available in barcode symbologies:
 ```
-    code-128     ean-128      dmtx         dmtx-s
-    dmtx-r       gs1-dmtx     gs1-dmtx-s   gs1-dmtx-r
+    ean-128     gs1-dmtx-s    gs1-qr-l   gs1-qr-q
+    gs1-dmtx    gs1-dmtx-r    gs1-qr-m   gs1-qr-h
 ```
 - Do not confuse this with &lt;FNC1&gt; character. Initially, it was intended to use the &lt;FNC1&gt; character as a separator character, but since according to [this stackoverflow answer](https://stackoverflow.com/questions/31318648/what-is-the-actual-hex-binary-value-of-the-gs1-fnc1-character/31322815#31322815) by Terry Burton, FNC1 is a non-data character that requires special treatment. And I dont want to fizzle around this when it is not necessary. Instead, I decided to use the &lt;GS&gt; character. According to the [GS1 General Specifications](https://www.gs1.org/standards/barcodes-epcrfid-id-keys/gs1-general-specifications), the &lt;FNC1&gt; and &lt;GS&gt; characters are in the role of a separator character substitutes. The `\FNC1` remained as a keyword for its uniqueness. If you need, you can replace it with `\GS` or any other keyword you consider unique.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Generate barcodes from a single PHP file. MIT license.
 
   * Output to PNG, GIF, JPEG, or SVG.
-  * Generates UPC-A, UPC-E, EAN-13, EAN-8, Code 39, Code 93, Code 128, Codabar, ITF, QR Code, and Data Matrix.
+  * Generates UPC-A, UPC-E, EAN-13, EAN-8, Code 39, Code 93, Code 128, GS1 128, Codabar, ITF, QR Code, DataMatrix and GS1 DataMatrix.
 
 Use from a PHP script:
 
@@ -110,3 +110,17 @@ barcode.php?f=svg&s=qr&d=HELLO%20WORLD&sf=8&ms=r&md=0.8
 `ww` - Width of wide modules and spaces. Applies to Code 39, Codabar, and ITF only. Default is 3.
 
 `wn` - Width of narrow space between characters. Applies to Code 39 and Codabar only. Default is 1.
+
+#### Keywords:
+
+`\FNC1`
+- used in `d` - Data option as a part of the data string.
+- when used, it is replaced with a Group separator &lt;GS&gt; ASCII char 29 in encoded data string.
+- it should be used to terminate variable length GS1 Application Identifiers in GS1 128 and GS1 DataMatrix barcodes.
+- if needed, you can replace `\FNC1` keyword with `yourKeyword` in barcode.php file, the functionality will remain. Do not forget to replace all occurrences.
+- available in barcode symbologies:
+```
+    code-128     ean-128      dmtx         dmtx-s
+    dmtx-r       gs1-dmtx     gs1-dmtx-s   gs1-dmtx-r
+```
+- Do not confuse this with &lt;FNC1&gt; character. Initially, it was intended to use the &lt;FNC1&gt; character as a separator character, but since according to [this stackoverflow answer](https://stackoverflow.com/questions/31318648/what-is-the-actual-hex-binary-value-of-the-gs1-fnc1-character/31322815#31322815) by Terry Burton, FNC1 is a non-data character that requires special treatment. And I dont want to fizzle around this when it is not necessary. Instead, I decided to use the &lt;GS&gt; character. According to the [GS1 General Specifications](https://www.gs1.org/standards/barcodes-epcrfid-id-keys/gs1-general-specifications), the &lt;FNC1&gt; and &lt;GS&gt; characters are in the role of a separator character substitutes. The `\FNC1` remained as a keyword for its uniqueness. If you need, you can replace it with `\GS` or any other keyword you consider unique.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Generate barcodes from a single PHP file. MIT license.
 
   * Output to PNG, GIF, JPEG, or SVG.
-  * Generates UPC-A, UPC-E, EAN-13, EAN-8, Code 39, Code 93, Code 128, GS1 128, Codabar, ITF, QR Code, DataMatrix and GS1 DataMatrix.
+  * Generates UPC-A, UPC-E, EAN-13, EAN-8, Code 39, Code 93, Code 128, GS1 128, Codabar, ITF, QR Code, GS1 QR Code, DataMatrix and GS1 DataMatrix.
 
 Use from a PHP script:
 
@@ -50,13 +50,13 @@ barcode.php?f=svg&s=qr&d=HELLO%20WORLD&sf=8&ms=r&md=0.8
 
 `s` - Symbology (type of barcode). One of:
 ```
-    upc-a          code-39         qr     dmtx
-    upc-e          code-39-ascii   qr-l   dmtx-s
-    ean-8          code-93         qr-m   dmtx-r
-    ean-13         code-93-ascii   qr-q   gs1-dmtx
-    ean-13-pad     code-128        qr-h   gs1-dmtx-s
-    ean-13-nopad   codabar                gs1-dmtx-r
-    ean-128        itf
+    upc-a          code-39         qr         gs1-qr-q     gs1-dmtx-r
+    upc-e          code-39-ascii   qr-l       gs1-qr-h
+    ean-8          code-93         qr-m       dmtx
+    ean-13         code-93-ascii   qr-q       dmtx-s
+    ean-13-pad     code-128        qr-h       dmtx-r
+    ean-13-nopad   codabar         gs1-qr-l   gs1-dmtx
+    ean-128        itf             gs1-qr-m   gs1-dmtx-s
 ```
 
 `d` - Data. For UPC or EAN, use `*` for missing digit. For Codabar, use `ABCD` or `ENT*` for start and stop characters. For QR, encode in Shift-JIS for kanji mode.

--- a/barcode-gs1-variable-length.html
+++ b/barcode-gs1-variable-length.html
@@ -1,0 +1,65 @@
+<html>
+
+<head>
+	<title>barcode.php gs1 variable length strings test</title>
+	<style>
+		body {
+			font-family: Helvetica, sans-serif;
+			padding: 1em;
+		}
+
+		.imgW20rem {
+			width: 20rem;
+		}
+
+		.list-unstyled {
+			list-style-type: none;
+		}
+
+		.d-flex {
+			display: flex;
+		}
+	</style>
+</head>
+
+<body>
+
+	<h3>GS1-128 codes with variable length Application Identifiers</h3>
+	<p>0</p>
+	<p><img src="barcode.php?s=ean-128&ts=3&th=12&d=00858000000000000007"></p>
+	<p>1</p>
+	<p><img src="barcode.php?s=ean-128&ts=3&th=12&d=0085800000000000000702085800000000093720"></p>
+	<p>2</p>
+	<p><img src="barcode.php?s=ean-128&ts=3&th=12&d=0085800000000000000702085800000000093720\FNC110LOT123"></p>
+
+	<h3>GS1-DataMatrix codes with variable length Application Identifiers</h3>
+	<p>3</p>
+	<div class="d-flex">
+		<img src="barcode.php?s=gs1-dmtx&d=0108580000000009">
+		<ul class="list-unstyled">
+			<li>(01) 08580000000009</li>
+		</ul>
+	</div>
+
+	<p>4</p>
+	<div class="d-flex">
+		<img src="barcode.php?s=gs1-dmtx&d=010858000000000910LOT123"></p>
+		<ul class="list-unstyled">
+			<li>(01) 08580000000009</li>
+			<li>(10) LOT123</li>
+		</ul>
+	</div>
+
+	<p>5</p>
+	<div class="d-flex">
+		<img src="barcode.php?s=gs1-dmtx&d=010858000000000910LOT123\FNC1211234567"></p>
+		<ul class="list-unstyled">
+			<li>(01) 08580000000009</li>
+			<li>(10) LOT123</li>
+			<li>(21) 1234567</li>
+		</ul>
+	</div>
+
+</body>
+
+</html>

--- a/barcode-gs1-variable-length.html
+++ b/barcode-gs1-variable-length.html
@@ -60,6 +60,33 @@
 		</ul>
 	</div>
 
+	<h3>GS1-QR codes with variable length Application Identifiers</h3>
+	<p>3</p>
+	<div class="d-flex">
+		<img src="barcode.php?s=gs1-qr-m&d=0108580000000009">
+		<ul class="list-unstyled">
+			<li>(01) 08580000000009</li>
+		</ul>
+	</div>
+
+	<p>4</p>
+	<div class="d-flex">
+		<img src="barcode.php?s=gs1-qr-m&d=010858000000000910LOT123"></p>
+		<ul class="list-unstyled">
+			<li>(01) 08580000000009</li>
+			<li>(10) LOT123</li>
+		</ul>
+	</div>
+
+	<p>5</p>
+	<div class="d-flex">
+		<img src="barcode.php?s=gs1-qr-h&d=010858000000000910LOT123\FNC1211234567"></p>
+		<ul class="list-unstyled">
+			<li>(01) 08580000000009</li>
+			<li>(10) LOT123</li>
+			<li>(21) 1234567</li>
+		</ul>
+	</div>
 </body>
 
 </html>

--- a/barcode.php
+++ b/barcode.php
@@ -1414,7 +1414,8 @@ class barcode_generator {
 
 	private function code_128_encode($data, $dstate, $fnc1) {
 		$data = preg_replace('/[\x80-\xFF]/', '', $data);
-		$label = preg_replace('/[\x00-\x1F\x7F]/', ' ', $data);
+		$labelData = str_replace('\FNC1', '', $data);
+		$label = preg_replace('/[\x00-\x1F\x7F]/', ' ', $labelData);
 		$chars = $this->code_128_normalize($data, $dstate, $fnc1);
 		$checksum = $chars[0] % 103;
 		for ($i = 1, $n = count($chars); $i < $n; $i++) {
@@ -1437,6 +1438,7 @@ class barcode_generator {
 	}
 
 	private function code_128_normalize($data, $dstate, $fnc1) {
+		$data = str_replace('\FNC1', chr(29), $data);
 		$detectcba = '/(^[0-9]{4,}|^[0-9]{2}$)|([\x60-\x7F])|([\x00-\x1F])/';
 		$detectc = '/(^[0-9]{6,}|^[0-9]{4,}$)/';
 		$detectba = '/([\x60-\x7F])|([\x00-\x1F])/';
@@ -2885,6 +2887,7 @@ class barcode_generator {
 
 	private function dmtx_encode_data($data, $rect, $fnc1) {
 		/* Convert to data codewords. */
+		$data = str_replace('\FNC1', chr(29), $data);
 		$edata = ($fnc1 ? array(232) : array());
 		$length = strlen($data);
 		$offset = 0;


### PR DESCRIPTION
Hi, I have added the Group Separator character to Code 128 and DataMatrix barcodes for separation of variable length GS1 Application Identifiers. It is used by using a keyword `\FNC1` anywhere in the `d` Data string. 
I like your library, it's easy to use and implement. The only thing I missed here was the separation of variable length GS1 AIs, so I decided to implement it myself. The chosen keyword may cause conflicts and confusion. The confusion is addressed in README. The conflicts are solvable by just changing the keyword  `\FNC1` to `somethingNotInConflict`.